### PR TITLE
Extract User persistence into registration command

### DIFF
--- a/web/commands/user/registration_command.ex
+++ b/web/commands/user/registration_command.ex
@@ -7,7 +7,7 @@ defmodule Mana.User.RegistrationCommand do
   end
 
   def run(registration_params \\ %{}) do
-    changeset = Registration.changeset(%Registration{}, registration_params)
+    changeset = prepare(registration_params)
     case Repo.insert(changeset) do
       {:ok, registration} -> {:ok, Registration.to_user(registration)}
       {:error, changeset} -> {:error, changeset}

--- a/web/commands/user/registration_command.ex
+++ b/web/commands/user/registration_command.ex
@@ -1,0 +1,16 @@
+defmodule Mana.User.RegistrationCommand do
+  use Mana.Web, :command
+  alias Mana.User.Registration
+
+  def prepare(registration_params \\ %{}) do
+   Registration.changeset(%Registration{}, registration_params)
+  end
+
+  def run(registration_params \\ %{}) do
+    changeset = Registration.changeset(%Registration{}, registration_params)
+    case Repo.insert(changeset) do
+      {:ok, registration} -> {:ok, Registration.to_user(registration)}
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+end

--- a/web/controllers/registration_controller.ex
+++ b/web/controllers/registration_controller.ex
@@ -1,15 +1,14 @@
 defmodule Mana.RegistrationController do
   use Mana.Web, :controller
-  alias Mana.User
+  alias Mana.User.RegistrationCommand
 
   def new(conn, _params) do
-    changeset = User.Registration.changeset(%User{})
-    render conn, "new.html", %{changeset: changeset}
+    changeset = RegistrationCommand.prepare()
+    render(conn, "new.html", %{changeset: changeset})
   end
 
-  def create(conn, %{"user" => user}) do
-    changeset = User.Registration.changeset(%User{}, user)
-    case Repo.insert(changeset) do
+  def create(conn, %{"registration" => registration_params}) do
+    case RegistrationCommand.run(registration_params) do
       {:ok, user} ->
         conn
         |> Guardian.Plug.sign_in(user)

--- a/web/controllers/registration_controller.ex
+++ b/web/controllers/registration_controller.ex
@@ -2,6 +2,8 @@ defmodule Mana.RegistrationController do
   use Mana.Web, :controller
   alias Mana.User.RegistrationCommand
 
+  plug :scrub_params, "registration" when action in [:create]
+
   def new(conn, _params) do
     changeset = RegistrationCommand.prepare()
     render(conn, "new.html", %{changeset: changeset})

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -4,8 +4,6 @@ defmodule Mana.User do
   schema "users" do
     field :username, :string
     field :encrypted_password, :string
-    field :password, :string, virtual: true
-    field :password_confirmation, :string, virtual: true
     timestamps
   end
 

--- a/web/models/user/registration.ex
+++ b/web/models/user/registration.ex
@@ -1,6 +1,14 @@
 defmodule Mana.User.Registration do
-  import Ecto.Changeset
+  use Mana.Web, :model
   import Mana.User
+
+  schema "users" do
+    field :username, :string
+    field :encrypted_password, :string
+    field :password, :string, virtual: true
+    field :password_confirmation, :string, virtual: true
+    timestamps
+  end
 
   def changeset(struct, params \\ %{}) do
     struct
@@ -9,5 +17,9 @@ defmodule Mana.User.Registration do
     |> validate_username
     |> validate_password
     |> hash_password
+  end
+
+  def to_user(struct) do
+    struct(Mana.User, Map.delete(struct, :__struct__))
   end
 end

--- a/web/web.ex
+++ b/web/web.ex
@@ -72,6 +72,14 @@ defmodule Mana.Web do
     end
   end
 
+  def command do
+    quote do
+      alias Mana.Repo
+      import Ecto
+      import Ecto.Query, only: [from: 1, from: 2]
+    end
+  end
+
   @doc """
   When used, dispatch to the appropriate controller/view/etc.
   """


### PR DESCRIPTION
Is this a good idea?

The point is to avoid the typical Rails mistake of polluting the User model with form specific fields (like password, password_confirmation). I moved those into Mana.User.Registration which is a model specific for the registration form.

Also, I moved the persistence logic into Mana.User.RegistrationCommand to simplify controllers. This also makes commands reusable, and easier to run from the Elixir console.
